### PR TITLE
Schedule import missed 3 teams, check for duplicate team in team list

### DIFF
--- a/client/app/global-actions/global-actions.component.html
+++ b/client/app/global-actions/global-actions.component.html
@@ -5,19 +5,19 @@
             <li class="grid-x grid-padding-x">
                 <div class="cell small-2" style="align-items: center;">
                     <span data-tooltip class="top" tabindex="2"
-                          title="Load schedule file created by Brian Lee's tournament scheduler"><i class="far fa-question-circle"></i></span>
+                          title="Import CSV schedule file created by Brian Lee's tournament scheduler"><i class="far fa-question-circle"></i></span>
                 </div>
                 <div class="cell small-10">
-                    <a data-open="tournament-data-upload">Load tournament schedule file</a>
+                    <a data-open="tournament-data-upload">Import schedule file</a>
                 </div>
             </li>
             <li class="grid-x grid-padding-x">
                 <div class="cell small-2" style="align-items: center;">
-                <span data-tooltip class="top" tabindex="2" title="CSV file with team number and name columns"><i
+                <span data-tooltip class="top" tabindex="2" title="Import CSV file with team number and name columns"><i
                         class="far fa-question-circle"></i></span>
                 </div>
                 <div class="cell small-10">
-                    <a data-open="teams-upload">Load team list</a>
+                    <a data-open="teams-upload">Import team list</a>
                 </div>
             </li>
         </ul>

--- a/client/app/modals/teams-upload/teams-upload.component.html
+++ b/client/app/modals/teams-upload/teams-upload.component.html
@@ -1,10 +1,14 @@
 <div id="teams-upload" class="fast reveal" [ngClass]="{ 'loading': loading }" data-reveal data-animation-in="hinge-in-from-middle-y" data-animation-out="hinge-out-from-middle-y">
-  <h2>Load team list</h2>
+  <h2>Import team list</h2>
   <div class="dimmer">
   	<div class="big loader"></div>
   </div>
 
-  <file-drop class="expanded button" [ngClass]="{ 'hollow': !fileHovering }" (onFileOver)="fileOver($event)" (onFileLeave)="fileLeave($event)" (onFileDrop)="dropped($event)">Drop your Teams CSV file here</file-drop>
+  <file-drop class="expanded button" [ngClass]="{ 'hollow': !fileHovering }" (onFileOver)="fileOver($event)" (onFileLeave)="fileLeave($event)" (onFileDrop)="dropped($event)">Drop your Team List CSV file here</file-drop>
+
+  <div class="grid-x align-center button-group">
+    <button class="button" *ngIf="teams" (click)="upload($event)" >Import</button>
+  </div>
 
   <table *ngIf="teams">
     <tr>
@@ -16,10 +20,6 @@
       <td>{{team.name}}</td>
     </tr>
   </table>
-
-  <div class="grid-x align-center button-group">
-    <button class="button" *ngIf="teams" (click)="upload($event)" >Upload</button>
-  </div>
 
   <button id="teams-close-button" class="close-button" data-close aria-label="Close modal" type="button">
     <span aria-hidden="true">&times;</span>

--- a/client/app/modals/teams-upload/teams-upload.component.ts
+++ b/client/app/modals/teams-upload/teams-upload.component.ts
@@ -32,7 +32,13 @@ export class TeamsUpload {
         fileReader.onload = (e) => {
           this.content = fileReader.result
           this.parser.parseTeams(this.content).subscribe((data: any) =>{
-            this.teams = data;
+            if(data['error']){
+              this.notifications.error(`Parsing of teams file failed.\n${data['error']}.`);
+              this.close();
+              this.loading = false;
+            }else{
+              this.teams = data['teams'];
+            }
           }, error => {
             this.notifications.error('Teams parsing failed');
           }, () => {
@@ -49,12 +55,12 @@ export class TeamsUpload {
   public upload(event) {
     this.loading = true
     this.teamsService.uploadBatch(this.content).subscribe(() => {
-      this.notifications.success('Teams uploaded');
+      this.notifications.success('Teams imported');
       this.close();
       this.loading = false;
       this.teamsService.reload();
     }, error => {
-      this.notifications.error('Teams upload failed');
+      this.notifications.error('Teams import failed');
       this.close();
       this.loading = false;
     });

--- a/client/app/modals/tournament-data-upload/tournament-data-upload.component.html
+++ b/client/app/modals/tournament-data-upload/tournament-data-upload.component.html
@@ -1,17 +1,17 @@
 <div id="tournament-data-upload" class="fast reveal" [ngClass]="{ 'loading': loading }" data-reveal
      data-animation-in="hinge-in-from-middle-y" data-animation-out="hinge-out-from-middle-y">
-    <h2>Load tournament schedule file</h2>
+    <h2>Import Tournament Schedule file</h2>
     <div class="dimmer">
         <div class="big loader"></div>
     </div>
 
     <file-drop class="expanded button" *ngIf="!data" [ngClass]="{ 'hollow': !fileHovering }"
                (onFileOver)="fileOver($event)" (onFileLeave)="fileLeave($event)" (onFileDrop)="dropped($event)">Drop
-        your Tournament CSV file here
+        your Tournament Scheduler CSV file here
     </file-drop>
 
     <div class="grid-x align-center button-group">
-        <button class="button" *ngIf="data" (click)="upload($event)">Upload</button>
+        <button class="button" *ngIf="data" (click)="upload($event)">Import</button>
     </div>
 
     <div class="grid-x" *ngIf="data">

--- a/client/app/modals/tournament-data-upload/tournament-data-upload.component.ts
+++ b/client/app/modals/tournament-data-upload/tournament-data-upload.component.ts
@@ -30,9 +30,15 @@ export class TournamentDataUpload {
         fileReader.onload = (e) => {
           this.content = fileReader.result
           this.parser.parseTournamentData(this.content).subscribe((data: any) => {
-            this.data = data;
+            if(data['error']){
+              this.notifications.error(`Parsing of Schedule file failed.\n${data['error']}.`);
+              this.close();
+              this.loading = false;
+            }else{
+              this.data = data;
+            }
           }, error => {
-            this.notifications.error('Tournament data parsing failed');
+            this.notifications.error('Parsing of Schedule file failed');
             this.close();
             this.loading = false;
           }, () => {
@@ -53,12 +59,12 @@ export class TournamentDataUpload {
   public upload(event) {
     this.loading = true
     this.tournamentDataService.upload(this.content).subscribe(() => {
-      this.notifications.success('Tournament data uploaded');
+      this.notifications.success('Schedule file imported');
       this.close();
       this.loading = false;
       this.tournamentDataService.reload();
     }, error => {
-      this.notifications.error('Tournament data upload failed');
+      this.notifications.error('Schedule file import failed');
       this.close();
       this.loading = false;
     });

--- a/logic/teamsBatchParser.js
+++ b/logic/teamsBatchParser.js
@@ -1,14 +1,29 @@
 'use strict'
 
 const objectDataParser = require('./objectDataParser')
+const MsLogger = require('@first-lego-league/ms-logger').Logger()
 
 exports.parse = function (data, delimiter) {
-  const teams = data.split('\n')
+  let errorStr
+  //Filter out lines without any data
+  const teams = data.split('\n').filter(line => line.trim()!=='')
     .map(line => objectDataParser.deserializeTeam(line.split(delimiter)))
-
+  
   if (teams.length > 0 && teams[0].number === undefined) {
     teams.unshift()
   }
+  MsLogger.info(`Parsing team list file. Found ${teams.length} team(s)`)
 
-  return teams
+  // Check for duplicate team numbers. Cause import to fail if found
+  const teamNumbersArray = teams.map(team => team.number)
+  const hasDuplicateTeam = teamNumbersArray.some((team, index) => {
+    return teamNumbersArray.indexOf(team) !== index
+  })
+  if(hasDuplicateTeam) {
+    errorStr = 'Duplicate team number found in team list. Aborting import'
+    MsLogger.warn(errorStr)
+    teams.length = 0
+  }
+  
+  return {'teams':teams,'error':errorStr}
 }

--- a/logic/tournamentDataParser.js
+++ b/logic/tournamentDataParser.js
@@ -1,5 +1,6 @@
 'use strict'
 const objectDataParser = require('./objectDataParser')
+const MsLogger = require('@first-lego-league/ms-logger').Logger()
 
 const Team = require('../models/Team')
 const Match = require('../models/Match')
@@ -21,6 +22,7 @@ const PRACTICE_MATCH_HEADER_LINE_AMOUNT = 6
 const TABLE_NAMES_START = 1
 
 function parse (data, delimiter) {
+  let errorStr
   const dataLines = data.split('\n')
 
   const lines = []
@@ -38,8 +40,19 @@ function parse (data, delimiter) {
     }
   })
 
-  const numOfTeams = lines[blocks.find(x => x.blockId === TEAM_DATA_BLOCK_ID).lineNumber + 1]
-  const teamsRaw = lines.slice(blocks.find(x => x.blockId === TEAM_DATA_BLOCK_ID).lineNumber + TEAM_DATE_HEADER_LINE_AMOUNT, parseInt(numOfTeams[1]))
+  const numOfTeamsRow = lines[blocks.find(x => x.blockId === TEAM_DATA_BLOCK_ID).lineNumber + 1]
+  const teamsRaw = lines.slice(blocks.find(x => x.blockId === TEAM_DATA_BLOCK_ID).lineNumber + TEAM_DATE_HEADER_LINE_AMOUNT, parseInt(numOfTeamsRow[1]) + TEAM_DATE_HEADER_LINE_AMOUNT+1)
+  MsLogger.log(`Parsing schedule file. Found ${teamsRaw.length} team(s)`)
+
+  // Check for duplicate team numbers. Cause import to fail if found
+  const teamNumbersArray = teamsRaw.map(team => team[0])
+  const hasDuplicateTeam = teamNumbersArray.some((team, index) => {
+    return teamNumbersArray.indexOf(team) !== index
+  })
+  if(hasDuplicateTeam) {
+    errorStr = 'Duplicate team number found in CSV. Aborting import.'
+    MsLogger.warn(errorStr)
+  }
 
   let rankingMatchesRaw, numOfActualFields, tablesRaw
   if (doesSectionExsits(blocks, RANKING_MATCH_SCHEDULE_ID)) {
@@ -84,7 +97,8 @@ function parse (data, delimiter) {
     'teams': teams,
     'tables': tables,
     'rankingMatches': rankingMatches,
-    'practiceMatches': practiceMatches
+    'practiceMatches': practiceMatches,
+    'error': errorStr
   }
 }
 

--- a/routers/teamsBatchUploadRouter.js
+++ b/routers/teamsBatchUploadRouter.js
@@ -34,7 +34,7 @@ exports.getRouter = function () {
       return res.status(400).send('Please provide delimiter..')
     }
 
-    const teams = teamsBatchParser.parse(req.body.teamsData, req.body.delimiter)
+    const teams = teamsBatchParser.parse(req.body.teamsData, req.body.delimiter).teams
     MongoClient.connect(MONGU_URI).then(connection => {
       return connection.db().collection('teams').insertMany(teams).then(() => {
         res.status(201).send()


### PR DESCRIPTION
1. For schedule file import, last 3 teams not imported
2. For team list import, check for duplicate team number
3. Use word "Import" instead of "upload" or "load" for consistency.

Problems:
1. After team list import the stage and delete button are not enabled
2. AFter team list import, the Teams screen is not reloaded
3. Schedule import dialog needs to be slightly wider to avoid wrep