### PR TITLE
fixed bug with searching for white spaces on table names

### DIFF
--- a/server/logic/data_parser.js
+++ b/server/logic/data_parser.js
@@ -126,5 +126,5 @@ function arrayContainesNonEmptyFields (arr) {
 }
 
 function isStringEmpty (str) {
-  return str == '' || str == undefined || /\s+/.test(str)
+  return str == '' || str == undefined || /^\s+$/.test(str)
 }


### PR DESCRIPTION
As explained in trello,
This is an error with looking for empty fields in an array, and instead looking for whitespaces