### PR TITLE
Write module version to log at startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const express = require('express')
 const path = require('path')
 const cors = require('cors')
 const bodyParser = require('body-parser')
+const version = require('project-version')
 const {correlationMiddleware} = require('@first-lego-league/ms-correlation')
 const {authenticationMiddleware, authenticationDevMiddleware} = require('@first-lego-league/ms-auth')
 const {loggerMiddleware, Logger} = require('@first-lego-league/ms-logger')
@@ -19,6 +20,7 @@ const appPort = process.env.PORT || 3001
 const authenticationMiddlewareToUse = process.env.DEV ? authenticationDevMiddleware() : authenticationMiddleware
 
 logger.setLogLevel(process.env.LOG_LEVEL || logger.LOG_LEVELS.DEBUG)
+logger.info (`-------------------- tournament version ${version} startup --------------------`)
 
 const app = express()
 app.use(bodyParser.urlencoded({extended: true}))

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "moment": "^2.22.1",
     "mongodb": "^3.0.0",
     "ng2-file-upload": "^1.3.0",
+    "project-version": "^1.2.0",
     "requestify": "^0.2.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5292,6 +5292,13 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+project-version@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/project-version/-/project-version-1.2.0.tgz#3c5b59cb53af9790bb21ebb87a9f21b0bf0b9815"
+  integrity sha512-o94hj3Ld7/7jeFPZEPuZxsbpeOsPqZMXh5iYIDS7rjhjj4UcYHDlb4pYi43qjXMYM3LUcD6qJhQq9siEzg1KIA==
+  dependencies:
+    read-pkg "^4.0.1"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -5505,6 +5512,15 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
+
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.6"


### PR DESCRIPTION
I want to make this a standard for all modules, including the common packages.
1. When reading the logfile it helps to know where startup is
1. Good to know what version of the module is running. It's possible to get it via the launcher but that is a lot of work.
1. common packages are important too - can identify modules with out-of-date packages.

I will update the Developer Guide after discussion.